### PR TITLE
fix: use milliseconds for sendMount interval times to fix windows tests

### DIFF
--- a/pkg/edgecache/manager_test.go
+++ b/pkg/edgecache/manager_test.go
@@ -105,8 +105,8 @@ func TestSendMount(t *testing.T) {
 			},
 		},
 	}
-	interval := time.Duration(1 * time.Microsecond)
-	timeout := time.Duration(10 * time.Millisecond)
+	interval := time.Duration(10 * time.Millisecond)
+	timeout := time.Duration(100 * time.Millisecond)
 	t.Run("WorksFirstTry", func(t *testing.T) {
 		client.EXPECT().AddMount(gomock.Any(), &addReq).Times(1).Return(&successRsp, nil)
 		ret := sendMount(client, account, container, targetPath, interval, timeout)


### PR DESCRIPTION
The short interval & timeout seem to fail on windows hosts.

I ran some tests on windows VM and it seems like the timeout can't be shorter than 80ms. So I extended it to 100 and increased the interval from microseconds to 10ms.

Works on VM and seems to work in github agent.