### PR TITLE
temporary patch for workload identity + cloud config as secret

### DIFF
--- a/pkg/blob/azure.go
+++ b/pkg/blob/azure.go
@@ -93,6 +93,17 @@ func getCloudProvider(kubeconfig, nodeID, secretName, secretNamespace, userAgent
 		if err != nil {
 			klog.V(2).Infof("InitializeCloudFromSecret: failed to get cloud config from secret %s/%s: %v", az.SecretNamespace, az.SecretName, err)
 		}
+
+		if tenantID := os.Getenv("AZURE_TENANT_ID"); tenantID != "" {
+			config.TenantID = tenantID
+		}
+		if clientID := os.Getenv("AZURE_CLIENT_ID"); clientID != "" {
+			config.AADClientID = clientID
+		}
+		if federatedTokenFile := os.Getenv("AZURE_FEDERATED_TOKEN_FILE"); federatedTokenFile != "" {
+			config.AADFederatedTokenFile = federatedTokenFile
+			config.UseFederatedWorkloadIdentityExtension = true
+		}
 	}
 
 	if config == nil {


### PR DESCRIPTION
When running the csi driver outside of AKS, there is no azure.json that gets created. So the cloud config has to be manually created and it _can_ come from a secret. In our case it will. While i wait for this PR to get looked at https://github.com/kubernetes-sigs/cloud-provider-azure/pull/4142 we can patch our fork to have a similar change.