### PR TITLE
nodeserver: safe exit when pvc is already being provisioned

### DIFF
--- a/pkg/blob/nodeserver.go
+++ b/pkg/blob/nodeserver.go
@@ -360,7 +360,13 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 
 		annotator := cv.NewPVCAnnotator(d.cloud.KubeClient)
 		providedAuth := cv.NewBlobAuth(accountName, containerName, secretName, secretNamespace, storageAuthType)
-		if err := annotator.SendProvisionVolume(pv, d.cloud.Config.AzureAuthConfig, providedAuth); err != nil {
+
+		err = annotator.SendProvisionVolume(pv, d.cloud.Config.AzureAuthConfig, providedAuth)
+		if err != nil {
+			if err == cv.ErrVolumeAlreadyBeingProvisioned {
+				return &csi.NodeStageVolumeResponse{}, nil
+			}
+
 			return nil, err
 		}
 

--- a/pkg/edgecache/cachevolume/pvc_annotator.go
+++ b/pkg/edgecache/cachevolume/pvc_annotator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cachevolume
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/exp/maps"
@@ -41,7 +42,8 @@ const (
 )
 
 var (
-	validStorageAuthentications = []string{"WorkloadIdentity", "AccountKey"}
+	validStorageAuthentications      = []string{"WorkloadIdentity", "AccountKey"}
+	ErrVolumeAlreadyBeingProvisioned = errors.New("pv is already being provisioned")
 )
 
 type BlobAuth struct {
@@ -145,9 +147,8 @@ func (c *PVCAnnotator) SendProvisionVolume(pv *v1.PersistentVolume, cloudConfig 
 	}
 
 	if prepare := c.needsToBeProvisioned(pvc); !prepare {
-		err := fmt.Errorf("pv is already being provisioned")
-		klog.Error(err)
-		return err
+		klog.Info("pv is already being provisioned")
+		return ErrVolumeAlreadyBeingProvisioned
 	}
 
 	annotations, err := c.buildAnnotations(pv, cloudConfig, providedAuth)


### PR DESCRIPTION
instead of causing an error if the pvc "stage volume" was called with is already being "staged" we silently exit