### PR TITLE
Exclude Hydra repo from CG scan.

### DIFF
--- a/pipelines/OneBranch.NonOfficial.yml
+++ b/pipelines/OneBranch.NonOfficial.yml
@@ -71,6 +71,8 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
+      cg:
+        ignoreDirectories: Hydra
     stages:
       - template: OneBranch.body.yml@self
         parameters:

--- a/pipelines/OneBranch.Official.yml
+++ b/pipelines/OneBranch.Official.yml
@@ -75,6 +75,8 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
+      cg:
+        ignoreDirectories: Hydra
     stages:
       - template: OneBranch.body.yml@self
         parameters:

--- a/pipelines/OneBranch.body.yml
+++ b/pipelines/OneBranch.body.yml
@@ -184,3 +184,7 @@ stages:
               images:
                 - $(BlobImageRepo)
 
+          - task: ComponentGovernanceComponentDetection@0
+            inputs:
+              ignoreDirectories: s # Hydra is checked out to "s"
+


### PR DESCRIPTION
Update the OneBranch pipeline to ignore the checkout of Hydra. Scanning it causes false positives for components.
